### PR TITLE
Add Discord Authentication

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -2,6 +2,10 @@ const LocalStrategy = require("passport-local").Strategy;
 const mongoose = require("mongoose");
 const User = require("../models/User");
 
+const DiscordStrategy = require('passport-discord').Strategy;
+// pulls discord username without email, and returns basic information about all the user's current guilds / servers. 
+const scopes = ['identify', 'guilds']
+
 module.exports = function (passport) {
   passport.use(
     new LocalStrategy({ usernameField: "email" }, (email, password, done) => {
@@ -38,4 +42,21 @@ module.exports = function (passport) {
   passport.deserializeUser((id, done) => {
     User.findById(id, (err, user) => done(err, user));
   });
+
+  //Discord authentication
+  passport.use(new DiscordStrategy({
+    //Get client ID and Secret from discord developer portal
+    clientID: process.env.DISCORD_CLIENT_ID,
+    clientSecret: process.env.DISCORD_CLIENT_SECRET,
+    callbackURL: 'localhost:3000',
+    scope: scopes
+  },
+  function(accessToken, refreshToken, profile, cb) {
+    User.findOrCreate({ discordId: profile.id }, function(err, user) {
+        return cb(err, user);
+    });
+  }));
+
+
+
 };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,11 @@ import Calendar from './components/Calendar';
 
 function App() {
   return (
-    <Calendar />
+    <div>
+      <Calendar />
+      {/* Test Link for Discord Authorization. Link comes from discord developer tools, redirects back to localhost:3000 for now */}
+      <a href="https://discord.com/api/oauth2/authorize?client_id=1039303417199345684&redirect_uri=http%3A%2F%2Flocalhost%3A3000&response_type=code&scope=identify%20guilds">Login With Discord</a>
+    </div>
   )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "multer": "^1.4.5-lts.1",
         "nodemon": "^2.0.7",
         "passport": "^0.6.0",
+        "passport-discord": "^0.1.4",
         "passport-local": "^1.0.0",
         "validator": "^13.6.0"
       }
@@ -213,6 +214,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -1538,6 +1547,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1606,6 +1620,14 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
+    "node_modules/passport-discord": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/passport-discord/-/passport-discord-0.1.4.tgz",
+      "integrity": "sha512-VJWPYqSOmh7SaCLw/C+k1ZqCzJnn2frrmQRx1YrcPJ3MQ+Oa31XclbbmqFICSvl8xv3Fqd6YWQ4H4p1MpIN9rA==",
+      "dependencies": {
+        "passport-oauth2": "^1.5.0"
+      }
+    },
     "node_modules/passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -1615,6 +1637,25 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -2014,6 +2055,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -2277,6 +2323,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -3265,6 +3316,11 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3311,12 +3367,32 @@
         "utils-merge": "^1.0.1"
       }
     },
+    "passport-discord": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/passport-discord/-/passport-discord-0.1.4.tgz",
+      "integrity": "sha512-VJWPYqSOmh7SaCLw/C+k1ZqCzJnn2frrmQRx1YrcPJ3MQ+Oa31XclbbmqFICSvl8xv3Fqd6YWQ4H4p1MpIN9rA==",
+      "requires": {
+        "passport-oauth2": "^1.5.0"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
       "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
       "requires": {
         "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz",
+      "integrity": "sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
       }
     },
     "passport-strategy": {
@@ -3631,6 +3707,11 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "undefsafe": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "multer": "^1.4.5-lts.1",
     "nodemon": "^2.0.7",
     "passport": "^0.6.0",
+    "passport-discord": "^0.1.4",
     "passport-local": "^1.0.0",
     "validator": "^13.6.0"
   }

--- a/routes/main.js
+++ b/routes/main.js
@@ -4,6 +4,7 @@ const authController = require("../controllers/auth");
 const homeController = require("../controllers/home");
 const postsController = require("../controllers/posts");
 const { ensureAuth, ensureGuest } = require("../middleware/auth");
+const passport = require("passport")
 
 //Main Routes - simplified for now
 router.get("/", homeController.getIndex);
@@ -15,4 +16,11 @@ router.get("/logout", authController.logout);
 router.get("/signup", authController.getSignup);
 router.post("/signup", authController.postSignup);
 
+//Discord Authentication Routes
+router.get('/auth/discord', passport.authenticate('discord'));
+router.get('/auth/discord/callback', passport.authenticate('discord', {
+    failureRedirect: '/'
+}), function(req, res) {
+    res.redirect('/')
+});
 module.exports = router;


### PR DESCRIPTION
Basic discord authentication added. Pulls username and what guild / servers they are a part of. If other information wanted check out https://discord.com/developers/docs/topics/oauth2. Temporary test login button added to App.js for testing purposes, at bottom of page. Created a discord developer portal team. We will need a way to share the secret without having to reset it constantly, it will break when reset. 

-Will need client ID and Secret from Discord Developer Portal - see passport.js

-Will need OAuth link if anything is changed in the portal or want redirect page changed. Currently redirecting after logging in to 
       localhost:3000. This link comes from the Discord Developer Portal as well. - see App.js  (temp button for testing created)


