### PR TITLE
bugfix: Update scripts to work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "concurrently \"npm:watch-client\" \"npm:watch-server\"",
     "watch-server": "nodemon server.js",
     "watch-client": "npm --prefix frontend start",
-    "postinstall": "npm --prefix frontend install && npm run build",
+    "postinstall": "cd frontend && npm install && cd ../ && npm run build",
     "build": "rm -rf build && cd ./frontend && npm run build --prod && cp -r build ../",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",


### PR DESCRIPTION
# Description

The prefix flag is not currently working on Windows with npm version that is greater than `8.1.2`. This PR update the scripts to make it compatible with Windows.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
