### PR TITLE
Fixed json-server path location.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "dev": "json-server --watch src/services/events.json --port 2121"
+    "dev": "json-server --watch src/test/events.json --port 2121"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "npm --prefix server run build:ui",
     "dev-concurrent": "concurrently \"npm:start-client\" \"npm:dev\"",
     "start-client": "npm --prefix client start",
+    "start-mockServer": "npm --prefix client run dev",
+    "dev-concurrent-mockServer": "concurrently \"npm:start-client\" \"npm:start-mockServer\"",
     "postinstall": "npm run build",
     "lint": "eslint .",
     "lint:fix": "eslint --fix",


### PR DESCRIPTION
# Description

Fixed json-server path location. Moved it to folder `client/src/test/event.js.` 

The script was previously listening to `src/services/events.js` instead of `sec/test/events.js`

Example of updated scripts: `"dev": "json-server --watch src/text/events.json --port 2121"`

Added new scripts: 

`"start-mockServer": "npm --prefix client run dev"`
`"dev-concurrent-mockServer": "concurrently "npm:start-client" "npm:start-mockServer""`

What is does:

`"concurrently"` - is a npm package to run multiple commands simultaneously.

`npm:start-client `- start script from `/client/package.json` which start `"start":"react-scripts start"`

`npm:star-mockServer` - start script `"dev": "json-server --watch src/test/events.json --port 2121"` located in
`/client/package.json`








## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
