### PR TITLE
Adding displayName to add event form and restricting editing

### DIFF
--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -4,13 +4,13 @@ import DataService from "services/dataService";
 
 export default function FormCreateEvent() {
   const { userData, setUserData } = useContext(FormMoverContext);
-
+  const [user, setUser] = useState();
   const handleChange = e => {
     const { name, value } = e.target;
     setUserData({ ...userData, [name]: value, discordName: user?.displayName });
   };
 
-  const [user, setUser] = useState();
+
   useEffect(() => {
     DataService.getCurrentUser().then(response => setUser(response.data));
   }, []);

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -9,15 +9,14 @@ export default function FormCreateEvent() {
 
   const handleChange = e => {
     const { name, value } = e.target;
-    setUserData({ ...userData, [name]: value,  discordName:user?.displayName });
+    setUserData({ ...userData, [name]: value, discordName: user?.displayName });
   };
 
   const [user, setUser] = useState();
   useEffect(() => {
-    DataService.getCurrentUser()
-      .then(response => setUser(response.data))
+    DataService.getCurrentUser().then(response => setUser(response.data));
   }, []);
-  console.log(userData)
+  console.log(userData);
 
   return (
     <div className="flex flex-col">

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -1,6 +1,4 @@
-import { useContext } from "react";
-import { useState } from "react";
-import { useEffect } from "react";
+import { useContext, useState, useEffect } from "react";
 import { FormMoverContext } from "./contexts/FormMoverContext";
 import DataService from "services/dataService";
 

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -14,7 +14,6 @@ export default function FormCreateEvent() {
   useEffect(() => {
     DataService.getCurrentUser().then(response => setUser(response.data));
   }, []);
-  console.log(userData);
 
   return (
     <div className="flex flex-col">

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -90,7 +90,7 @@ export default function FormCreateEvent() {
             onChange={handleChange}
             value={user?.displayName || ""}
             name="discordName"
-            disabled="true"
+            disabled={true}
             placeholder="Discord Name"
             className="p-1 px-2 appearance-none outline-non w-full text-gray-800"
           />

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -1,13 +1,23 @@
 import { useContext } from "react";
+import { useState } from "react";
+import { useEffect } from "react";
 import { FormMoverContext } from "./contexts/FormMoverContext";
+import DataService from "services/dataService";
 
 export default function FormCreateEvent() {
   const { userData, setUserData } = useContext(FormMoverContext);
 
   const handleChange = e => {
     const { name, value } = e.target;
-    setUserData({ ...userData, [name]: value });
+    setUserData({ ...userData, [name]: value,  discordName:user?.displayName });
   };
+
+  const [user, setUser] = useState();
+  useEffect(() => {
+    DataService.getCurrentUser()
+      .then(response => setUser(response.data))
+  }, []);
+  console.log(userData)
 
   return (
     <div className="flex flex-col">
@@ -82,8 +92,9 @@ export default function FormCreateEvent() {
           <input
             type="text"
             onChange={handleChange}
-            value={userData["discordName"] || ""}
+            value={user?.displayName || ""}
             name="discordName"
+            disabled="true"
             placeholder="Discord Name"
             className="p-1 px-2 appearance-none outline-non w-full text-gray-800"
           />

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -12,13 +12,13 @@ class DataService {
     return URL.post(`/events/create`, msg);
   }
   getAll() {
-    return URL.get('/events')
+    return URL.get("/events");
   }
   getById(id) {
-    return URL.get(`/events/${id}`)
+    return URL.get(`/events/${id}`);
   }
   getCurrentUser() {
-    return URL.get('/getDisplayName')
+    return URL.get("/getDisplayName");
   }
 }
 

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -17,6 +17,9 @@ class DataService {
   getById(id) {
     return URL.get(`/events/${id}`)
   }
+  getCurrentUser() {
+    return URL.get('/getDisplayName')
+  }
 }
 
 export default new DataService();

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -19,7 +19,7 @@ module.exports = {
         recurringDates: data.recurring.days,
         recurringRate: data.recurring.rate,
         location: data.location,
-        discordName: data.discordName,
+        discordName: req.user.displayName,
       });
       res.json({ message: "Event created!" });
     } catch (err) {
@@ -30,7 +30,7 @@ module.exports = {
     try {
       const events = await Event.find();
       // return all events
-      res.json(events)
+      res.json(events);
     } catch (err) {
       console.log(err);
     }
@@ -42,5 +42,5 @@ module.exports = {
     } catch (err) {
       console.log(err);
     }
-  }
+  },
 };

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -11,4 +11,8 @@ router.get('/', eventsController.getAll);
 
 router.get('/:id', eventsController.getOne);
 
+router.get('/getDisplayName', (req, res) =>{
+    res.json(req.user || null)
+  });
+
 module.exports = router;

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -11,8 +11,4 @@ router.get("/", eventsController.getAll);
 
 router.get("/:id", eventsController.getOne);
 
-router.get("/getDisplayName", (req, res) => {
-  res.json(req.user || null);
-});
-
 module.exports = router;

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -7,12 +7,12 @@ router.get("/ping", eventsController.ping);
 
 router.post("/create", eventsController.create);
 
-router.get('/', eventsController.getAll);
+router.get("/", eventsController.getAll);
 
-router.get('/:id', eventsController.getOne);
+router.get("/:id", eventsController.getOne);
 
-router.get('/getDisplayName', (req, res) =>{
-    res.json(req.user || null)
-  });
+router.get("/getDisplayName", (req, res) => {
+  res.json(req.user || null);
+});
 
 module.exports = router;

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -13,5 +13,8 @@ router.get(
     successRedirect: authRedirectUrl,
   })
 );
+router.get('/getDisplayName', (req, res) =>{
+  res.json(req.user || null)
+});
 
 module.exports = router;

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const passport = require("passport");
 
 //Main Routes - simplified for now
-const authRedirectUrl = process.env.OAUTH_REDIRECT_URL || 'http://localhost:3000'
+const authRedirectUrl =
+  process.env.OAUTH_REDIRECT_URL || "http://localhost:3000";
 //Discord Authentication Routes
 router.get("/auth/discord", passport.authenticate("discord"));
 router.get(
@@ -13,8 +14,8 @@ router.get(
     successRedirect: authRedirectUrl,
   })
 );
-router.get('/getDisplayName', (req, res) =>{
-  res.json(req.user || null)
+router.get("/getDisplayName", (req, res) => {
+  res.json(req.user || null);
 });
 
 module.exports = router;


### PR DESCRIPTION
# Description

This PR prevents user input into the discord name field and prevents the ability user from editing the field. Additionally, I changed the events object to use the `req.user.displayName` to catch bad actors that try to manually edit the state before submitting it to the DB. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Issue
- [x] Is this related to a specific issue? Is so please specify:
#84 

# Checklist:

- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
