### PR TITLE
109 - Use login auth to prevent users from completing the add-event-form

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,24 +7,37 @@ import { Context } from "./contexts/Context"
 
 function App() {
   const [context, setContext] = useState({user: null})
+  const [page, setPage] = useState("landingPage")
 
   useEffect(() => {
     DataService.getCurrentUser().then(response => {
       setContext({ user: response.data })
+      console.log(response.data)
     });
   }, []);
 
   return (
     <Context.Provider value={[context, setContext]}>
+      {context.user && 
+        <h3>Hello, {context.user.displayName}, welcome to Together!</h3>
+      }
       <LoginWithDiscord />
-      {!context.user && <>
+      {page === "landingPage" && <>
+        <button onClick={() => setPage("calendarPage")}>
+          Navigate to Calendar
+        </button>
         <h1>Hello, landingPage goes here</h1>
       </>}
-      {context.user && <>
+      {page === "calendarPage" && <>
+        <button onClick={() => setPage("landingPage")}>
+          Navigate to LandingPage
+        </button>
         <Calendar />
-        <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
-          <UserForm />
-        </div>
+        {context.user && 
+          <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
+            <UserForm />
+          </div>
+        }
       </>}
     </Context.Provider>
   )

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,34 +1,46 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Calendar from "features/calendar/Calendar";
 import LoginWithDiscord from "features/auth/LoginWithDiscord";
 import UserForm from "features/form/UserForm";
+import DataService from "services/dataService";
+import { Context } from "./contexts/Context"
 
 function App() {
-  const [page, setPage] = useState("landingPage");  
+  const [context, setContext] = useState({user: null, page: "landingPage"})
 
-  if (page === "landingPage") {
-    return (
-      <>
+  const setPage = (page) => {
+    context.page = page
+    setContext({...context})
+  }
+
+  useEffect(() => {
+    DataService.getCurrentUser().then(response => {
+      context.user = response.data;
+      setContext({...context})
+      console.log(context.user)
+    });
+  }, []);
+
+  return (
+    <Context.Provider value={[context, setContext]}>
+      {context.page === "landingPage" && <>
         <h1>Hello, landingPage goes here</h1>
         <button onClick={() => setPage("calendarPage")}>
           Navigate to Calendar
         </button>
-      </>
-    ) 
-  } else if (page === "calendarPage") {
-    return (
-      <div>
+        <LoginWithDiscord />
+      </>}
+      {context.page === "calendarPage" && <>
         <button onClick={() => setPage("landingPage")}>
           Navigate to LandingPage
         </button>
-        <LoginWithDiscord />
         <Calendar />
         <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
           <UserForm />
         </div>
-      </div>
-    )
-  }
+      </>}
+    </Context.Provider>
+  )
 }
 
 export default App;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -28,7 +28,7 @@ function App() {
         <button onClick={() => setPage("calendarPage")}>
           Navigate to Calendar
         </button>
-        <LoginWithDiscord />
+        {!context.user && <LoginWithDiscord />}
       </>}
       {context.page === "calendarPage" && <>
         <button onClick={() => setPage("landingPage")}>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,8 +10,7 @@ function App() {
 
   useEffect(() => {
     DataService.getCurrentUser().then(response => {
-      context.user = response.data;
-      setContext({...context})
+      setContext({ user: response.data })
     });
   }, []);
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,34 +6,22 @@ import DataService from "services/dataService";
 import { Context } from "./contexts/Context"
 
 function App() {
-  const [context, setContext] = useState({user: null, page: "landingPage"})
-
-  const setPage = (page) => {
-    context.page = page
-    setContext({...context})
-  }
+  const [context, setContext] = useState({user: null})
 
   useEffect(() => {
     DataService.getCurrentUser().then(response => {
       context.user = response.data;
       setContext({...context})
-      console.log(context.user)
     });
   }, []);
 
   return (
     <Context.Provider value={[context, setContext]}>
-      {context.page === "landingPage" && <>
+      <LoginWithDiscord />
+      {!context.user && <>
         <h1>Hello, landingPage goes here</h1>
-        <button onClick={() => setPage("calendarPage")}>
-          Navigate to Calendar
-        </button>
-        {!context.user && <LoginWithDiscord />}
       </>}
-      {context.page === "calendarPage" && <>
-        <button onClick={() => setPage("landingPage")}>
-          Navigate to LandingPage
-        </button>
+      {context.user && <>
         <Calendar />
         <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
           <UserForm />

--- a/client/src/contexts/Context.js
+++ b/client/src/contexts/Context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const Context = createContext();

--- a/client/src/features/auth/LoginWithDiscord.js
+++ b/client/src/features/auth/LoginWithDiscord.js
@@ -5,7 +5,7 @@ import DataService from "services/dataService";
 const LoginWithDiscord = () => {
   const [context, setContext] = useContext(Context)
   return (
-    <>
+    <div>
       {!context.user && 
         <form action="/auth/discord">
           <button type="submit">Login with Discord</button>
@@ -18,7 +18,7 @@ const LoginWithDiscord = () => {
           setContext({...context})
         }}>Logout</button>
       }
-    </>
+    </div>
   );
 };
 

--- a/client/src/features/auth/LoginWithDiscord.js
+++ b/client/src/features/auth/LoginWithDiscord.js
@@ -1,10 +1,24 @@
-import React from "react";
+import React, {useContext} from "react";
+import { Context } from "contexts/Context";
+import DataService from "services/dataService";
 
 const LoginWithDiscord = () => {
+  const [context, setContext] = useContext(Context)
   return (
-    <form action="/auth/discord">
-      <button type="submit">Login with Discord</button>
-    </form>
+    <>
+      {!context.user && 
+        <form action="/auth/discord">
+          <button type="submit">Login with Discord</button>
+        </form>
+      }
+      {context.user &&
+        <button onClick={() => {
+          DataService.logout()
+          context.user = null
+          setContext({...context})
+        }}>Logout</button>
+      }
+    </>
   );
 };
 

--- a/client/src/features/form/FormCreateEvent.js
+++ b/client/src/features/form/FormCreateEvent.js
@@ -1,19 +1,14 @@
-import { useContext, useState, useEffect } from "react";
+import { useContext } from "react";
 import { FormMoverContext } from "./contexts/FormMoverContext";
-import DataService from "services/dataService";
+import { Context } from "contexts/Context";
 
 export default function FormCreateEvent() {
   const { userData, setUserData } = useContext(FormMoverContext);
-  const [user, setUser] = useState();
+  const [context] = useContext(Context)
   const handleChange = e => {
     const { name, value } = e.target;
-    setUserData({ ...userData, [name]: value, discordName: user?.displayName });
+    setUserData({ ...userData, [name]: value, discordName: context.user?.displayName });
   };
-
-
-  useEffect(() => {
-    DataService.getCurrentUser().then(response => setUser(response.data));
-  }, []);
 
   return (
     <div className="flex flex-col">
@@ -88,7 +83,7 @@ export default function FormCreateEvent() {
           <input
             type="text"
             onChange={handleChange}
-            value={user?.displayName || ""}
+            value={context.user?.displayName || ""}
             name="discordName"
             disabled={true}
             placeholder="Discord Name"

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -20,6 +20,9 @@ class DataService {
   getCurrentUser() {
     return URL.get("/getDisplayName");
   }
+  logout() {
+    return URL.get("/auth/logout")
+  }
 }
 
 export default new DataService();

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -7,6 +7,16 @@ const authRedirectUrl =
   process.env.OAUTH_REDIRECT_URL || "http://localhost:3000";
 //Discord Authentication Routes
 router.get("/auth/discord", passport.authenticate("discord"));
+router.get("/auth/logout", (req, res) => {
+  req.logout(() => {
+    console.log('User has logged out.')
+  })
+  req.session.destroy((err) => {
+    if (err) console.log('Error : Failed to destroy the session during logout.', err)
+    req.user = null
+    return res.json({message: 'Logout successful.'})
+  })
+});
 router.get(
   "/auth/discord/callback",
   passport.authenticate("discord", {

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -14,7 +14,7 @@ router.get("/auth/logout", (req, res) => {
   req.session.destroy((err) => {
     if (err) console.log('Error : Failed to destroy the session during logout.', err)
     req.user = null
-    return res.json({message: 'Logout successful.'})
+    return res.json({ message: 'Logout successful.' })
   })
 });
 router.get(


### PR DESCRIPTION
FIxes #109 

# Description

Created Context.js to store universal app state like the 'user' object. Added context to App.js and FormCreateEvent.js.

Updated LoginWithDiscord with conditional rendering based on whether context.user is truthy.
-LoginWithDiscord now displays 'logout' functionality if context.user is truthy.

Added conditional rendering based on context in App.js.
-Calendar page only displays Event Form if context.user is truthy.

Added Logout functionality.
-Added logout() to Data Service.
-Added /auth/logout route to main routes.
-Added logout() method to main routes that uses passport's built-in logout() method and destroys their session in mongoDB.

Updated FormCreateEvent.js 
-Replaced user state variable with context.user.
-Made form pull user discordName from context.user.
-Moved getCurrentUser() useEffect call from FormCreateEvent to App.js.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issue
- [x] Is this related to a specific issue? Is so please specify: #109 

# Checklist:

- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
