### PR TITLE
Change button element to div, remove console warning, fix #197

### DIFF
--- a/client/src/features/home/DiscordButton.js
+++ b/client/src/features/home/DiscordButton.js
@@ -4,12 +4,11 @@ import LoginWithDiscord from "features/auth/LoginWithDiscord";
 const DiscordButton = () => (
   <>
     <div className=" flex -mx-10 border-2 border-slate-400 bg-[#b5c8d3] py-[0.1px] rounded">
-      <button className="md:px-10 px-2 py-1 my-3 mx-auto bg-discordBtn rounded text-base font-bold">
+      <div className="md:px-10 px-2 py-1 my-3 mx-auto bg-discordBtn rounded text-base font-bold">
         <LoginWithDiscord />
-      </button>
+      </div>
     </div>
   </>
 );
 
 export default DiscordButton;
-


### PR DESCRIPTION
# Description

Remove the console warning about nested \<button\> elements by changing one button to div. The appearance remains the same.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue
- [x] Is this related to a specific issue? Is so please specify: #197 

# Checklist:

- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
