### PR TITLE
Fix LongCard resize issue on Landingpage.js by adding flex box to App.js

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,7 +25,7 @@ function App() {
       }
       {context.page === "landingPage" &&
       <div className="bg-primary overflow-hidden flex justify-center items-center h-screen">
-        <div className="w-1/3">
+        <div className="flex w-1/3">
           <LandingPage />
         </div>
       </div>


### PR DESCRIPTION
# Description

<LongCard> in LandingPage.js was resizing differently than the <ShortCards>. Turned the App.js div holding the landingpage.js into a flex box. This stopped the one <LongCard> component from getting smaller, and when the edge touches the w-1/3 limit, it then continues to flex-wrap appropriately.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue
- [X] Is this related to a specific issue? Is so please specify:
Issue #173
# Checklist:

- [X] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
