### PR TITLE
Turned Modal into Reusable Component #190

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import Calendar from "features/calendar/Calendar";
 import UserForm from "features/form/UserForm";
 import Modal from "features/modal/Modal";
+import EventModal from "features/modal/EventModal";
 import { useRoutingContext } from "contexts/RoutingContext";
 import { useAuthContext } from "contexts/AuthContext";
 import LandingPage from "features/home/LandingPage";
@@ -31,7 +32,9 @@ function App() {
         <Calendar />
         <FormProvider>
           <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
-            <Modal type={'event'} open={'eventModal'}/>
+            <Modal>
+              <EventModal />
+            </Modal>
             {auth?.user && 
                 <UserForm />
             }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,12 +5,14 @@ import Modal from "features/modal/Modal";
 import EventModal from "features/modal/EventModal";
 import { useRoutingContext } from "contexts/RoutingContext";
 import { useAuthContext } from "contexts/AuthContext";
+import { useModalContext } from "contexts/ModalContext";
 import LandingPage from "features/home/LandingPage";
 import FormProvider from "contexts/FormContext";
 
 function App() {
   const routing = useRoutingContext();
   const auth = useAuthContext();
+  const modal = useModalContext();
   const isAuthenticated = auth.isAuthenticated();
 
   return (
@@ -32,11 +34,11 @@ function App() {
         <Calendar />
         <FormProvider>
           <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
-            <Modal>
+            <Modal context={modal}>
               <EventModal />
             </Modal>
             {auth?.user && 
-                <UserForm />
+              <UserForm />
             }
           </div>
         </FormProvider>

--- a/client/src/contexts/ModalContext/index.js
+++ b/client/src/contexts/ModalContext/index.js
@@ -12,8 +12,8 @@ export const useModalContext = () => {
 // Creating a provider to wrap components that needs to acess Auth/User's data
 // Note: a provider is a special component that pass the context to its children to access
 const ModalProvider = ({ children }) => {
-  const auth = useProvideModal();
-  return <ModalContext.Provider value={auth}>{children}</ModalContext.Provider>;
+  const modal = useProvideModal();
+  return <ModalContext.Provider value={modal}>{children}</ModalContext.Provider>;
 };
 
 export default ModalProvider;

--- a/client/src/contexts/ModalContext/useProvideModal.js
+++ b/client/src/contexts/ModalContext/useProvideModal.js
@@ -4,7 +4,7 @@ import { useState } from "react";
 // Allow us to check and modify any methods/functions in one place.
 const useProvideModal = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [activeModal, setActiveModal] = useState(null);
+  const [activeEvent, setActiveEvent] = useState(null);
 
   const handleOpen = () => {
     setIsOpen(true);
@@ -23,8 +23,8 @@ const useProvideModal = () => {
     handleOpen,
     handleClose,
     handleToggle,
-    activeModal,
-    setActiveModal
+    activeEvent,
+    setActiveEvent
   }
 };
 

--- a/client/src/features/calendar/Event.js
+++ b/client/src/features/calendar/Event.js
@@ -9,7 +9,7 @@ const Event = (props) => {
   return (
     <button
       onClick={() => {
-        modal.setActiveModal(props.event)
+        modal.setActiveEvent(props.event)
         modal.handleOpen();
       }}
       key={props.event.title}

--- a/client/src/features/modal/EventModal.jsx
+++ b/client/src/features/modal/EventModal.jsx
@@ -38,7 +38,7 @@ const EventModal = () => {
       }
       {authorCheck &&
         <button
-          className="w-auto h-10 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl text-sm hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300 inline-block"
+          className="w-auto h-10 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300 inline-block"
           onClick={() => dataService.deleteAllEvents(modal.activeEvent.groupId).then(modal.handleClose)}
         >
           Delete All Events

--- a/client/src/features/modal/EventModal.jsx
+++ b/client/src/features/modal/EventModal.jsx
@@ -11,7 +11,7 @@ import dataService from '../../services/dataService';
 import { useAuthContext } from "contexts/AuthContext";
 
 
-const EventModal = ({ handleClose }) => {
+const EventModal = () => {
   const modal = useModalContext();
 
   //grabs user compares user from context and event author
@@ -24,25 +24,25 @@ const EventModal = ({ handleClose }) => {
     <div className="flex flex-col items-center py-0 px-2rem rounded-xl bg-white pb-4">
       <button
         className="w-auto h-12 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300"
-        onClick={handleClose}
+        onClick={modal.handleClose}
       >
         Close
       </button>
       {authorCheck &&
-      <button
-        className="w-auto h-12 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300"
-        onClick={() => dataService.deleteEvent(modal.activeModal._id).then(handleClose) }
-      >
-        Delete Specific Event
-      </button>
+        <button
+          className="w-auto h-12 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300"
+          onClick={() => dataService.deleteEvent(modal.activeModal._id).then(modal.handleClose)}
+        >
+          Delete Specific Event
+        </button>
       }
       {authorCheck &&
-      <button
-        className="w-auto h-10 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl text-sm hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300 inline-block"
-        onClick={() => dataService.deleteAllEvents(modal.activeModal.groupId).then(handleClose) }
-      >
-        Delete All Events
-      </button>
+        <button
+          className="w-auto h-10 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl text-sm hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300 inline-block"
+          onClick={() => dataService.deleteAllEvents(modal.activeModal.groupId).then(modal.handleClose)}
+        >
+          Delete All Events
+        </button>
       }
       <div className="w-4/6 mt-3 flex flex-col">
         <h2 className=" flex mb-1 border-solid border-b-2 border-black font-semibold">
@@ -76,7 +76,7 @@ const EventModal = ({ handleClose }) => {
             <IoLocationOutline className="mt-1" /> <span>Location: {modal.activeModal.location}</span>
           </section>
           <section className="flex m-3 gap-1 font-semibold">
-              <IoPersonOutline className="mt-1" /> <span>Event Author: {modal.activeModal.user?.displayName || "Deleted"}</span>
+            <IoPersonOutline className="mt-1" /> <span>Event Author: {modal.activeModal.user?.displayName || "Deleted"}</span>
           </section>
         </div>
       </div>

--- a/client/src/features/modal/EventModal.jsx
+++ b/client/src/features/modal/EventModal.jsx
@@ -18,7 +18,7 @@ const EventModal = () => {
   //displays delete buttons if true
   const { user } = useAuthContext();
   const userId = user?._id;
-  const authorCheck = userId === modal.activeModal.user._id
+  const authorCheck = userId === modal.activeEvent.user._id
 
   return (
     <div className="flex flex-col items-center py-0 px-2rem rounded-xl bg-white pb-4">
@@ -31,7 +31,7 @@ const EventModal = () => {
       {authorCheck &&
         <button
           className="w-auto h-12 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300"
-          onClick={() => dataService.deleteEvent(modal.activeModal._id).then(modal.handleClose)}
+          onClick={() => dataService.deleteEvent(modal.activeEvent._id).then(modal.handleClose)}
         >
           Delete Specific Event
         </button>
@@ -39,44 +39,44 @@ const EventModal = () => {
       {authorCheck &&
         <button
           className="w-auto h-10 mt-5 px-2 border-solid border-2 border-gray outline-none rounded font-semibold text-xl text-sm hover:bg-teal-600 active:bg-teal-700 focus:outline-none focus:ring focus:ring-teal-300 inline-block"
-          onClick={() => dataService.deleteAllEvents(modal.activeModal.groupId).then(modal.handleClose)}
+          onClick={() => dataService.deleteAllEvents(modal.activeEvent.groupId).then(modal.handleClose)}
         >
           Delete All Events
         </button>
       }
       <div className="w-4/6 mt-3 flex flex-col">
         <h2 className=" flex mb-1 border-solid border-b-2 border-black font-semibold">
-          <img className="w-8 pr-2" src={togetherLogo} alt="" /> {modal.activeModal.title}
+          <img className="w-8 pr-2" src={togetherLogo} alt="" /> {modal.activeEvent.title}
         </h2>
         <div className="dateTime">
           <section className="flex m-3 gap-1 font-semibold">
             <GrCalendar className="mt-1" />
             <span className="">Day:</span>{" "}
-            <span>{format(parseISO(modal.activeModal.startAt), 'M')}/{format(parseISO(modal.activeModal.startAt), 'd')}/{format(parseISO(modal.activeModal.startAt), 'y')}</span>
+            <span>{format(parseISO(modal.activeEvent.startAt), 'M')}/{format(parseISO(modal.activeEvent.startAt), 'd')}/{format(parseISO(modal.activeEvent.startAt), 'y')}</span>
           </section>
 
           <section className="flex m-3 gap-1 font-semibold">
             <FaRegClock className="mt-1" />
-            <span className=" "> Starts: {formatToLocalTime(modal.activeModal.startAt)}</span>
-            <span className="ml-9">Ends: {formatToLocalTime(modal.activeModal.endAt)}</span>
+            <span className=" "> Starts: {formatToLocalTime(modal.activeEvent.startAt)}</span>
+            <span className="ml-9">Ends: {formatToLocalTime(modal.activeEvent.endAt)}</span>
           </section>
         </div>
         <div className="description break-words w-auto min-h-20 my-2 p-2 border-solid border-black border-2 font-semibold rounded-xl bg-neutral-200/50">
-          <p>Description: {modal.activeModal.description}</p>
+          <p>Description: {modal.activeEvent.description}</p>
         </div>
         <div>
           {/* <section className="flex m-3 gap-1 font-semibold">
             <IoIosRepeat className="mt-1" />
             <span>
               Repeats:
-              {modal.activeModal.recurring ? <div>{modal.activeModal.recurringPattern.days.join(', ')}, {modal.activeModal.recurringPattern.rate}</div> : <div>Does not repeat.</div>}
+              {modal.activeEvent.recurring ? <div>{modal.activeEvent.recurringPattern.days.join(', ')}, {modal.activeEvent.recurringPattern.rate}</div> : <div>Does not repeat.</div>}
             </span>
           </section> */}
           <section className="flex m-3 gap-1 font-semibold">
-            <IoLocationOutline className="mt-1" /> <span>Location: {modal.activeModal.location}</span>
+            <IoLocationOutline className="mt-1" /> <span>Location: {modal.activeEvent.location}</span>
           </section>
           <section className="flex m-3 gap-1 font-semibold">
-            <IoPersonOutline className="mt-1" /> <span>Event Author: {modal.activeModal.user?.displayName || "Deleted"}</span>
+            <IoPersonOutline className="mt-1" /> <span>Event Author: {modal.activeEvent.user?.displayName || "Deleted"}</span>
           </section>
         </div>
       </div>

--- a/client/src/features/modal/Modal.jsx
+++ b/client/src/features/modal/Modal.jsx
@@ -1,10 +1,9 @@
 import { AnimatePresence } from "framer-motion";
-import EventModal from "./EventModal";
 import Backdrop from "./Backdrop";
 import { motion } from "framer-motion";
 import { useModalContext } from "contexts/ModalContext";
 
-const Modal = (props) => {
+const Modal = ({ children }) => {
   const modal = useModalContext();
 
   const dropIn = {
@@ -45,7 +44,7 @@ const Modal = (props) => {
               animate="visible"
               exit="exit"
             >
-              <EventModal handleClose={modal.handleClose} />
+              {children}
             </motion.div>
           </Backdrop>
         }

--- a/client/src/features/modal/Modal.jsx
+++ b/client/src/features/modal/Modal.jsx
@@ -1,10 +1,8 @@
 import { AnimatePresence } from "framer-motion";
 import Backdrop from "./Backdrop";
 import { motion } from "framer-motion";
-import { useModalContext } from "contexts/ModalContext";
 
-const Modal = ({ children }) => {
-  const modal = useModalContext();
+const Modal = ({ children, context }) => {
 
   const dropIn = {
     hidden: {
@@ -34,8 +32,8 @@ const Modal = ({ children }) => {
         exitBeforeEnter={true}
         onExitComplete={() => null}
       >
-        {modal.isOpen &&
-          <Backdrop onClick={modal.handleClose}>
+        {context.isOpen &&
+          <Backdrop onClick={context.handleClose}>
             <motion.div
               className="modal"
               onClick={e => e.stopPropagation()}


### PR DESCRIPTION
# Description

Modal.jsx is now a wrapper. You can pass in a component between <Modal></Modal>, and that component will appear as the body of the modal. If you pass in a context object as a prop called 'context', that context will be given control the modal.

### Feature changes:
- Removed unused handleClose prop from EventModal.jsx, used handleClose method provided by modal context object instead.
- Passed EventModal into Modal component as child prop.
- Removed reference to EventModal from Modal.jsx, used props.children instead, allowing any component to be passed into the modal wrapper as a child.
- Modal.jsx no longer controlled by specific context. Relevant context is now passed into Modal.jsx as a prop, allowing for multiple contexts to control multiple different modals.

### Small fixes:
- Renamed const auth to modal to match naming conventions of other contexts.
- Renamed activeModal and setActiveModal in modal context to activeEvent and setActiveEvent to better clarify what is being set.
- Removed text-sm from tailwindcss in line 41 that was causing warning.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue
- [x] Is this related to a specific issue? Is so please specify: #190 

# Checklist:

- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
