### PR TITLE
Add functionality to Calendar Header

### DIFF
--- a/client/src/features/calendarHeader/CalendarHeader.js
+++ b/client/src/features/calendarHeader/CalendarHeader.js
@@ -13,8 +13,13 @@ function CalendarHeader({ date }) {
   const { isAuthenticated, logout } = useAuthContext();
   const { setCurrentPage } = useRoutingContext();
 
-  const TOGETHER_THREAD_URL =
+  const DISCORD_THREAD_URL =
     "discord://discord.com/channels/735923219315425401/1038482732633825442";
+  const GH_ISSUES_URL = "https://github.com/Caleb-Cohen/Together/issues";
+
+  const linkToUrl = url => {
+    window.open(url, "_blank");
+  };
 
   const handleLogin = () => {
     window.location = "/auth/discord";
@@ -27,7 +32,7 @@ function CalendarHeader({ date }) {
         <HeaderButton
           Icon={MdGroupAdd}
           tooltipText="Join Team"
-          onClick={() => window.open(TOGETHER_THREAD_URL, "_blank")}
+          onClick={() => linkToUrl(DISCORD_THREAD_URL)}
         />
         <HeaderButton
           Icon={FaHome}
@@ -45,8 +50,16 @@ function CalendarHeader({ date }) {
         />
       </section>
       <section className="flex space-x-3">
-        <HeaderButton Icon={IoChatbubblesOutline} tooltipText="Feedback" />
-        <HeaderButton Icon={FaQuestion} tooltipText="Help" />
+        <HeaderButton
+          Icon={IoChatbubblesOutline}
+          tooltipText="Feedback"
+          onclick={() => linkToUrl(GH_ISSUES_URL)}
+        />
+        <HeaderButton
+          Icon={FaQuestion}
+          tooltipText="Help"
+          onClick={() => linkToUrl(GH_ISSUES_URL)}
+        />
         {isAuthenticated() ? (
           <HeaderButton
             Icon={RiArrowLeftCircleFill}

--- a/client/src/features/calendarHeader/CalendarHeader.js
+++ b/client/src/features/calendarHeader/CalendarHeader.js
@@ -53,7 +53,7 @@ function CalendarHeader({ date }) {
         <HeaderButton
           Icon={IoChatbubblesOutline}
           tooltipText="Feedback"
-          onclick={() => linkToUrl(GH_ISSUES_URL)}
+          onClick={() => linkToUrl(GH_ISSUES_URL)}
         />
         <HeaderButton
           Icon={FaQuestion}

--- a/client/src/features/calendarHeader/CalendarHeader.js
+++ b/client/src/features/calendarHeader/CalendarHeader.js
@@ -2,14 +2,17 @@ import HeaderButton from "./components/HeaderButton";
 import { MdGroupAdd } from "react-icons/md";
 import { IoChatbubblesOutline } from "react-icons/io5";
 import { BsCalendarPlusFill } from "react-icons/bs";
-import { FaQuestion } from "react-icons/fa";
+import { FaHome, FaQuestion } from "react-icons/fa";
 import { RiArrowLeftCircleFill, RiArrowRightCircleFill } from "react-icons/ri";
 import MonthAndYear from "features/calendar/MonthAndYear";
 import Logo from "../../assets/images/togetherLogo.svg";
 import { useAuthContext } from "contexts/AuthContext";
+import { useRoutingContext } from "contexts/RoutingContext";
 
 function CalendarHeader({ date }) {
   const { isAuthenticated, logout } = useAuthContext();
+  const { setCurrentPage } = useRoutingContext();
+
   const TOGETHER_THREAD_URL =
     "discord://discord.com/channels/735923219315425401/1038482732633825442";
 
@@ -25,6 +28,11 @@ function CalendarHeader({ date }) {
           Icon={MdGroupAdd}
           tooltipText="Join Team"
           onClick={() => window.open(TOGETHER_THREAD_URL, "_blank")}
+        />
+        <HeaderButton
+          Icon={FaHome}
+          tooltipText={"Home"}
+          onClick={() => setCurrentPage("landingPage")}
         />
       </section>
       <section className="flex items-center">

--- a/client/src/features/home/CalendarPage.js
+++ b/client/src/features/home/CalendarPage.js
@@ -2,7 +2,6 @@ import useDate from "hooks/useDate";
 import Calendar from "../calendar/Calendar";
 import CalendarHeader from "../calendarHeader";
 import FormProvider from "contexts/FormContext";
-import { useRoutingContext } from "contexts/RoutingContext";
 import Modal from "features/modal/Modal";
 import UserForm from "features/form/UserForm";
 import { useAuthContext } from "contexts/AuthContext";


### PR DESCRIPTION
# Description

This adds functionality to the buttons in the calendar header.

- [x] Add a button to the nav bar that has the functionality to return to landing page.
- [ ] Have the add event modal trigger on button press (Pending Turn Create Event Form into a Modal #157).
- [ ] Remove add event form to the bottom of the login (Pending #157) 
- [x] Add feedback button functionality. I'd love a modal popup that allows users to type in their feedback to submit, but that may be a little much to start now. It could redirect directly to the issues tab on github so users can post their feedback/issus.
- [x] Add help button functionality. Can be just a modal popup with a link to the discord group thread, and github issues tab.

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue
Closes #245 
Closes #176 

# Checklist:

- [x] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
