### PR TITLE
nestedParagraphs without package-lock

### DIFF
--- a/client/src/features/home/BottomCard.js
+++ b/client/src/features/home/BottomCard.js
@@ -5,10 +5,10 @@ const BottomCard = ({ heading, title, description, img }) => (
     <section className="tablet:flex tablet:justify-between h-fit border-solid border-2 border-black rounded-lg shadow-lg bg-secondary py-16 tablet:pt-10 px-6 tab">
       <div className=" tablet:w-2/3 tablet:px-20">
         <h3 className=" text-center text-2xl font-bold pb-10">{heading}</h3>
-        <p className="font-semibold text-sm tablet:text-base laptop:text-lg">
+        <div className="font-semibold text-sm tablet:text-base laptop:text-lg">
           <span className="font-bold">{title}</span>
           {description}
-        </p>
+        </div>
       </div>
       <div className=" tablet:w-1/3 self-center tablet:pr-10 "> 
         <img src={img} alt="two people sitting" />


### PR DESCRIPTION
# Description
Rebase of #287 

On BottomCard.js - I changed the "p" to "div" and fixed the console error caused by the nested "p".

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue
- [x] Is this related to a specific issue? Is so please specify: #278 

# Checklist:

- [x] This PR is up to date with the development branch, and merge conflicts have been resolved
- [ ] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
