### PR TITLE
Plus date interface

### DIFF
--- a/client/src/features/calendar/DayCard.js
+++ b/client/src/features/calendar/DayCard.js
@@ -2,9 +2,11 @@ import { isSameDay, format } from "date-fns";
 import React from "react";
 import Event from "./Event";
 import { useFormModalContext } from "contexts/FormModalContext";
+import { useFormContext } from "contexts/FormContext";
 
 const DayCard = ({ date, events }) => {
-
+  const { setFormData } = useFormContext();
+  
   const formModal = useFormModalContext();
 
   //Extracts month in long format from date object
@@ -41,7 +43,11 @@ const DayCard = ({ date, events }) => {
 
       <button 
         className="absolute bottom-0 right-0 items-center justify-center hidden w-6 h-6 mb-2 mr-2 text-white bg-gray-400 rounded group-hover:flex hover:bg-gray-500"
-        onClick={formModal.handleOpen}
+        onClick={() => {
+          let chosenDate = `${date.getFullYear()}-${(date.getMonth()+1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`
+          setFormData(prevFormData => ({ ...prevFormData, initialDate: chosenDate }))
+          formModal.handleOpen()
+        }}
       >
         <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
           <path

--- a/client/src/features/calendar/DayCard.js
+++ b/client/src/features/calendar/DayCard.js
@@ -45,7 +45,7 @@ const DayCard = ({ date, events }) => {
         className="absolute bottom-0 right-0 items-center justify-center hidden w-6 h-6 mb-2 mr-2 text-white bg-gray-400 rounded group-hover:flex hover:bg-gray-500"
         onClick={() => {
           let chosenDate = `${date.getFullYear()}-${(date.getMonth()+1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`
-          setFormData(prevFormData => ({ ...prevFormData, initialDate: chosenDate }))
+          setFormData(prevFormData => ({ ...prevFormData, initialDate: chosenDate, finalDate: chosenDate }))
           formModal.handleOpen()
         }}
       >

--- a/client/src/features/home/CalendarPage.js
+++ b/client/src/features/home/CalendarPage.js
@@ -24,29 +24,24 @@ function CalendarPage() {
   };
 
   return (
-    <>
-      <main
-        onWheel={handleWheelScroll}
-        className="flex flex-col gap-3 p-3 shadow-sm min-h-screen max-w-[1920px] mx-auto"
-      >
+    <FormProvider>
+      <main onWheel={handleWheelScroll} className="flex flex-col gap-3 p-3 shadow-sm min-h-screen max-w-[1920px] mx-auto">
         <CalendarHeader date={date} />
         <Calendar date={date} />
       </main>
       {auth?.user && (
-        <FormProvider>
-          <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
-            <Modal context={modal}>
-              <EventModal />
+        <div className="md:w-1/2 mx-auto shadow-xl rounded-2xl pb-2 bg-white">
+          <Modal context={modal}>
+            <EventModal />
+          </Modal>
+          {auth?.user && 
+            <Modal context={formModal}>
+              <UserForm />
             </Modal>
-            {auth?.user && (
-              <Modal context={formModal}>
-                <UserForm />
-              </Modal>
-            )}
-          </div>
-        </FormProvider>
+          }
+        </div>
       )}
-    </>
+      </FormProvider>
   );
 }
 export default CalendarPage;


### PR DESCRIPTION
# Description

When the plus button was clicked originally, it would only show the current year.
Now when the plus button is clicked it adds the month and date of the clicked date on the calendar. 
Changed onClick in the dayCard.js File
Edited FormProvider in calendarPage.js file. Removed React fragment and interchanged it with  FormProvider

## Type of change

Please select everything applicable. Please, do not delete any lines.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue
- [X] Is this related to a specific issue? If so, please specify: #304 

# Checklist:

- [X] This PR is up to date with the development branch, and merge conflicts have been resolved
- [X] I have executed `npm run lint` and resolved any outstanding errors. Most issues can be solved by executing `npm run format`
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
